### PR TITLE
Do not install text files in site-packages/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ homepage = "https://github.com/lukapecnik/NiaAML"
 repository = "https://github.com/lukapecnik/NiaAML"
 readme = "README.rst"
 include = [
-    "LICENSE",
-    "CHANGELOG.md",
-    "CITATION.md"
+    { path="LICENSE", format="sdist" },
+    { path="CHANGELOG.md", format="sdist" },
+    { path="CITATION.md", format="sdist" }
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
By restricting these files to the sdist, they are included in the `.tar.gz` but the wheel does not install them in the root of the Python `site-packages` directory.

The `LICENSE` file is still automatically included in the wheel’s `dist-info` directory.