### PR TITLE
Eschew deprecated numpy aliases for builtins

### DIFF
--- a/niaaml/pipeline.py
+++ b/niaaml/pipeline.py
@@ -472,7 +472,7 @@ class _PipelineProblem(Problem):
                         )
                         if (
                             i[0][key].param_type is np.intc
-                            or i[0][key].param_type is np.int
+                            or i[0][key].param_type is int
                             or i[0][key].param_type is np.uintc
                             or i[0][key].param_type is np.uint
                         ):

--- a/niaaml/preprocessing/feature_selection/select_k_best.py
+++ b/niaaml/preprocessing/feature_selection/select_k_best.py
@@ -62,8 +62,8 @@ class SelectKBest(FeatureSelectionAlgorithm):
         """
         if self.__k is None:
             self.__k = x.shape[1]
-            self._params["k"] = ParameterDefinition(MinMax(1, self.__k), np.int)
-            val = np.int(np.around(np.random.uniform(1, self.__k)))
+            self._params["k"] = ParameterDefinition(MinMax(1, self.__k), int)
+            val = int(np.around(np.random.uniform(1, self.__k)))
             self.__select_k_best.set_params(k=val)
 
         self.__select_k_best.fit(x, y)

--- a/niaaml/preprocessing/feature_selection/variance_threshold.py
+++ b/niaaml/preprocessing/feature_selection/variance_threshold.py
@@ -30,7 +30,7 @@ class VarianceThreshold(FeatureSelectionAlgorithm):
 
     def __init__(self, **kwargs):
         r"""Initialize VarianceThreshold feature selection algorithm."""
-        self._params = dict(threshold=ParameterDefinition(MinMax(0, 0.1), np.float))
+        self._params = dict(threshold=ParameterDefinition(MinMax(0, 0.1), float))
         self.__variance_threshold = VarThr()
 
     def set_parameters(self, **kwargs):

--- a/niaaml/utilities.py
+++ b/niaaml/utilities.py
@@ -20,7 +20,7 @@ def get_bin_index(value, number_of_bins):
     Returns:
         uint: Calculated index.
     """
-    bin_index = np.int(np.floor(value / (1.0 / number_of_bins)))
+    bin_index = int(np.floor(value / (1.0 / number_of_bins)))
     if bin_index >= number_of_bins:
         bin_index -= 1
     return bin_index


### PR DESCRIPTION
Replaces “np.int” with “int”, and “np.float” with “float”, since these
aliases are deprecated in numpy 1.20.0. See
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
for details and justification.

Fixes #56.